### PR TITLE
修复BUG: 消息回复速度过快引起未查到ID错误

### DIFF
--- a/index.js
+++ b/index.js
@@ -264,13 +264,8 @@ class RPC {
         params,
         id
       }
-      
+
       this.logger.debug(`0MQ [${id}] => [${clientId}] ${JSON.stringify(data)}`)
-      
-      let msg = [msgpack.pack(data)]
-      if (this.isServer) msg.unshift(Buffer.from(clientId, 'base64'))
-      this.socket.send(msg)
-      
       Reflect.set(this.promisedRequests, id, {
         method,
         params,
@@ -285,6 +280,11 @@ class RPC {
           })
         }, this.callTimeout)
       })
+
+      let msg = [msgpack.pack(data)]
+      if (this.isServer) msg.unshift(Buffer.from(clientId, 'base64'))
+      this.socket.send(msg)
+
     })
   }
 


### PR DESCRIPTION
在基站环境下(node4.8.3, zmq-jsonrpc0.2.0, zmq2.15.3)， 消息回复时间小于 0.005 秒， 每5秒一次消息调用的情况下，半小时内大概会触发此BUG 2次到3次。